### PR TITLE
UIY-3913 Change route for creating mocks, too

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Docker assigns automatically an open port. To see the assigned port use `$ docke
 
 ### Create a mock / Save a response
 
-    POST [url]?session_id=[session_id]
+    POST [url]/api-mock/create?session_id=[session_id]
     {
         "status_code": 200,
         "headers": { ... },
@@ -64,7 +64,7 @@ Docker assigns automatically an open port. To see the assigned port use `$ docke
 A GET request to the root URL of the API mock will return the count of unsent
 mock responses for the given session.
 
-    GET [url]/api-mock/?session_id=[session_id]
+    GET [url]/api-mock/count?session_id=[session_id]
 
 `$ curl [url]?session_id=[session_id]`
 * **url:** *URL to API Mock*

--- a/config/routes/mock.php
+++ b/config/routes/mock.php
@@ -6,7 +6,7 @@
  */
 return [
     [
-        'pattern'   => '',
+        'pattern'   => 'api-mock/create',
         'route'     => 'mock/mock/create',
         'verb'      => 'POST',
     ],

--- a/tests/api/Mock/Controller/MockControllerCest.php
+++ b/tests/api/Mock/Controller/MockControllerCest.php
@@ -17,7 +17,7 @@ class MockControllerCest
      */
     public function tryToSaveResponse(\ApiTester $I)
     {
-        $I->sendPOST('/', [
+        $I->sendPOST('/api-mock/create', [
             'data' => [
                 'test' => 'api'
             ],
@@ -68,7 +68,7 @@ class MockControllerCest
      */
     public function tryToStoreClientRequest(\ApiTester $I)
     {
-        $I->sendPOST('/', [
+        $I->sendPOST('/api-mock/create', [
             'session_id'  => 'apitest',
             'status_code' => HttpCode::OK,
             'headers'     => ['Content-Type' => 'application/json'],


### PR DESCRIPTION
I thought that we could prevent changing that route,
but we still see some errors with this.
Therefore, the endpoint for CREATING responses was
changes as well. Please consider using the updated
version of surplex/api-mock-api!